### PR TITLE
Timeout functionality

### DIFF
--- a/hamtsolo.cabal
+++ b/hamtsolo.cabal
@@ -33,7 +33,6 @@ executable hamtsolo
                      , resourcet            >= 1.1
                      , stm-conduit          >= 3.0
                      , unix                 >= 2.7
-                     , word8                >= 0.1
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
Introducing a new thread that decrements a watchdog timer value every second and kills the connection if it runs down to `0`.
At the same time, the receiving message handler resets the watchdog timer to `20` again on every message it receives.